### PR TITLE
Update path in streaming docs

### DIFF
--- a/docs/streaming-implementation.md
+++ b/docs/streaming-implementation.md
@@ -29,7 +29,7 @@ class MessageCreate(MessageBase):
 FastAPIの`StreamingResponse`を使用して、Server-Sent Events (SSE) 形式でデータをストリーミングします：
 
 ```python
-# backend/app/api/chat/chat.py
+# backend/app/api/v1/chat/chat.py
 from fastapi.responses import StreamingResponse
 import json
 


### PR DESCRIPTION
## Summary
- fix path in streaming implementation docs

## Testing
- `pytest -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68443fd62364832a9a2c3e68b599f284