### PR TITLE
Fix race condition and cleanup token on email failure

### DIFF
--- a/backend/app/api/v1/auth/auth.py
+++ b/backend/app/api/v1/auth/auth.py
@@ -332,6 +332,10 @@ async def password_reset_request(
             await send_password_reset_email(user.email, token)
         except Exception as e:
             logger.error(f"Failed to send password reset email: {str(e)}")
+            # Remove the token if sending fails so it cannot be reused
+            user.reset_token = None
+            user.reset_token_expires_at = None
+            db.commit()
             # メール送信エラー時も同一の成功メッセージを返す（セキュリティ対策）
             pass
 

--- a/backend/app/core/token.py
+++ b/backend/app/core/token.py
@@ -41,11 +41,22 @@ def generate_reset_token() -> str:
 
 
 def set_reset_token(db: Session, user: User, hours: int = 1) -> str:
-    """Generate a password reset token, persist it on the user record and return it.
+    """Generate and persist a password reset token for ``user``.
 
-    The token is valid for the specified number of `hours` (default: 1 hour).
+    Row-level locking is used to avoid race conditions when multiple requests
+    attempt to generate a reset token for the same user concurrently.
+
+    The token is valid for ``hours`` hours (default: 1).
     """
     from datetime import timezone  # 遅延インポートで循環参照を防止
+
+    # Acquire a row-level lock to prevent concurrent token updates for the same user
+    user = (
+        db.query(User)
+        .filter(User.id == user.id)
+        .with_for_update()
+        .one()
+    )
 
     token = generate_reset_token()
     expires_at = datetime.now(timezone.utc) + timedelta(hours=hours)


### PR DESCRIPTION
## Summary
- ensure `set_reset_token` uses a row lock to avoid concurrent updates
- remove reset token if sending email fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6856c894b734832aabaa1a14b7d5a41f